### PR TITLE
replace println with tracing info

### DIFF
--- a/crates/libsolv_rs/Cargo.toml
+++ b/crates/libsolv_rs/Cargo.toml
@@ -14,6 +14,7 @@ readme.workspace = true
 itertools = "0.11.0"
 petgraph = "0.6.3"
 rattler_conda_types = { version = "0.5.0", path = "../rattler_conda_types" }
+tracing = "0.1.37"
 
 [dev-dependencies]
 insta = "1.29.0"


### PR DESCRIPTION
Replaces all println's with tracing.

Im not sure if this is true but I believe the final log string is not created if the log message is filtered. This would reduce some overhead but Im not entirely sure if this is actually true...